### PR TITLE
Resolve lists of referenced resources as url list

### DIFF
--- a/projects/ngx-hal-client/src/lib/core/util/resource-helper.ts
+++ b/projects/ngx-hal-client/src/lib/core/util/resource-helper.ts
@@ -98,6 +98,9 @@ export class ResourceHelper {
                         array.forEach((element) => {
                             if (Utils.isPrimitive(element)) {
                                 result[key].push(element);
+                            } else if (ResourceHelper.className(element)
+                                .find((className: string) => className === 'Resource') || element._links) {
+                                result[key].push(element._links.self.href);
                             } else {
                                 result[key].push(this.resolveRelations(element));
                             }


### PR DESCRIPTION
I came across a problem with a one-to-many relation between two resources. Say I have the resources _ResourceA_ and _ResourceB_. _ResourceA_ has an attribute that references a list of many _ResourceB_ objects. Currently, the list of _ResourceB_ is resolved as a list of objects in POST, PUT and PATCH requests. However, I would expect it to be a list of URLs instead, since it is a list of resources and not embedded objects.

This change adds another check to the list handling of resolveRelations, which checks if an object is a resource. It references resources using their url instead of the object representation.